### PR TITLE
feat: web service YouTube vía HTTP

### DIFF
--- a/controladores/youtube.controlador.php
+++ b/controladores/youtube.controlador.php
@@ -1,0 +1,39 @@
+<?php
+class YoutubeControlador
+{
+    static public function obtenerVideo($q)
+    {
+        $API_KEY = 'AIzaSyCiX4EW012jNOBcaQRPraG1tR8YLKwhV_s'; // tu API key
+
+        // Construimos la URL de la petición
+        $url = sprintf(
+            'https://youtube.googleapis.com/youtube/v3/search?part=snippet&q=%s&maxResults=1&type=video&key=%s',
+            urlencode($q),
+            $API_KEY
+        );
+
+        // Hacemos la llamada HTTP
+        $json = @file_get_contents($url);
+        if ($json === false) {
+            return ['error' => 'No se pudo conectar con YouTube API'];
+        }
+
+        $data = json_decode($json, true);
+        if (empty($data['items'][0])) {
+            return ['error' => 'No se encontraron videos'];
+        }
+
+        $item = $data['items'][0];
+        $videoId   = $item['id']['videoId'] ?? null;
+        $snippet   = $item['snippet'] ?? [];
+        $title     = $snippet['title'] ?? '';
+        $thumbnail = $snippet['thumbnails']['default']['url'] ?? '';
+
+        return [
+            'videoId'   => $videoId,
+            'title'     => $title,
+            'thumbnail' => $thumbnail,
+            'url'       => 'https://www.youtube.com/watch?v=' . $videoId
+        ];
+    }
+}

--- a/rutas/rutas.php
+++ b/rutas/rutas.php
@@ -292,6 +292,27 @@ if (count($arrayRutas) === 3
 }
 
 
+if (
+    $_SERVER['REQUEST_METHOD'] === 'GET' &&
+    ($_GET['ruta'] ?? '') === 'video'
+) {
+    require_once 'controladores/youtube.controlador.php';
+    header('Content-Type: application/json');
+
+    if (empty($_GET['q'])) {
+        echo json_encode(['error' => 'Parámetro "q" requerido']);
+        exit;
+    }
+
+    $resultado = YoutubeControlador::obtenerVideo($_GET['q']);
+    echo json_encode($resultado);
+    exit;
+}
+
+
+
+
+
 
 
 ?>


### PR DESCRIPTION
Este PR agrega un nuevo endpoint REST que, usando una llamada HTTP directa a la YouTube Data API v3,
devuelve el primer video de YouTube para el parámetro de búsqueda `q`. 
Se accede vía: GET /index.php?ruta=video&q=nombre+del+curso
